### PR TITLE
Fixing a crash with exporting data

### DIFF
--- a/TransTracks/Assets.xcassets/Contents.json
+++ b/TransTracks/Assets.xcassets/Contents.json
@@ -1,6 +1,6 @@
 {
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/TransTracks/UI/Settings/SettingsController.swift
+++ b/TransTracks/UI/Settings/SettingsController.swift
@@ -346,7 +346,9 @@ class SettingsController: BackgroundGradientViewController {
                 
                 //Sharing the resulting zip
                 let activityViewController = UIActivityViewController(activityItems: [tempZipUrl], applicationActivities: nil)
-                self.present(activityViewController, animated: true, completion: nil)
+                DispatchQueue.main.async {
+                    self.present(activityViewController, animated: true, completion: nil)
+                }
             } catch {
                 self.stopLoading()
                 AlertHelper.showMessage(title: NSLocalizedString("error", comment: ""), message: NSLocalizedString("exportFailure", comment: ""))


### PR DESCRIPTION
Seems like the OS is stricter now with ensuring changes to the UI are made on the UI thread causing a crash